### PR TITLE
Use UnsafeCell for CFI_STATE

### DIFF
--- a/lib/src/cfi_counter.rs
+++ b/lib/src/cfi_counter.rs
@@ -61,7 +61,7 @@ impl Default for CfiInt {
 }
 
 fn prng() -> &'static Xoshiro128 {
-    unsafe { &CFI_STATE.prng }
+    unsafe { &(*CFI_STATE.get()).prng }
 }
 
 /// CFI counter
@@ -174,8 +174,8 @@ impl CfiCounter {
     pub fn read() -> CfiInt {
         unsafe {
             CfiInt::from_raw(
-                core::ptr::read_volatile(&CFI_STATE.val as *const u32),
-                core::ptr::read_volatile(&CFI_STATE.mask as *const u32),
+                core::ptr::read_volatile(&(*CFI_STATE.get()).val as *const u32),
+                core::ptr::read_volatile(&(*CFI_STATE.get()).mask as *const u32),
             )
         }
     }
@@ -183,8 +183,8 @@ impl CfiCounter {
     /// Write counter value
     fn write(val: CfiInt) {
         unsafe {
-            core::ptr::write_volatile(&mut CFI_STATE.val as *mut u32, val.val);
-            core::ptr::write_volatile(&mut CFI_STATE.mask as *mut u32, val.masked_val);
+            core::ptr::write_volatile(&mut (*CFI_STATE.get()).val as *mut u32, val.val);
+            core::ptr::write_volatile(&mut (*CFI_STATE.get()).mask as *mut u32, val.masked_val);
         }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -19,6 +19,8 @@ pub use cfi::*;
 pub use cfi_counter::{CfiCounter, CfiInt};
 pub use xoshiro::Xoshiro128;
 
+use core::cell::UnsafeCell;
+
 #[repr(C)]
 pub struct CfiState {
     val: u32,
@@ -36,5 +38,5 @@ static mut CFI_STATE: CfiState = CfiState {
 #[cfg(not(feature = "cfi-test"))]
 extern "C" {
     #[link_name = "CFI_STATE_ORG"]
-    static mut CFI_STATE: CfiState;
+    static CFI_STATE: UnsafeCell<CfiState>;
 }


### PR DESCRIPTION
In rust, sharing a mutable reference in undefined behavior. UnsafeCell instructs the compiler to turn off noalias so it does not assume the CFI_STATE hasn't been changed.